### PR TITLE
query router for max link speed for rra setup

### DIFF
--- a/create-rra.py
+++ b/create-rra.py
@@ -9,15 +9,25 @@ four datasources which are counters
 three RRA for one day, one week and one mont
 """
 
+import fritzconnection
 import rrdtool
 import os
 
 from common import read_configuration
 
+def get_link_speed():
+    fc = fritzconnection.FritzConnection()
+    status = fc.call_action('WANCommonInterfaceConfig', 'GetCommonLinkProperties')
+    downstream = status['NewLayer1DownstreamMaxBitRate'] / 8.
+    upstream = status['NewLayer1UpstreamMaxBitRate'] / 8.
+    return (upstream, downstream)
+
 def main():
+    link_speeds = get_link_speed()
+    max_speeds = tuple([speed*1.1 for speed in link_speeds])
     rrdtool.create(prefs['rra_filename'], '--step', '60',
-        'DS:bytes-up:COUNTER:500:0:'+prefs['max_transferrate'],
-        'DS:bytes-down:COUNTER:500:0:'+prefs['max_transferrate'],
+        'DS:bytes-up:COUNTER:500:0:'+str(max_speeds[0]),
+        'DS:bytes-down:COUNTER:500:0:'+str(max_speeds[1]),
         'RRA:AVERAGE:0.8:1:1440',
         'RRA:AVERAGE:0.8:10:1008',
         'RRA:AVERAGE:0.8:60:5040' )

--- a/fritz-speed.ini
+++ b/fritz-speed.ini
@@ -4,9 +4,6 @@ graph_height: 300
 graph_width: 500
 graph_basedir: /var/www/htdocs/pics
 
-# maximum transferrate in Bytes/s which will be accepted as a valid value
-max_transferrate: 150000000
-
 # definitions of graphs to be plotted
 # each section corresponds to one graph
 [day]


### PR DESCRIPTION
Query router for max link speed to include this as the maximum allowed
value plus a 10% error margin as the maximum allowed value of a data
point in the rra.

remove max_transferspeed from configuration file because it is determined
automatically.

closes #1
